### PR TITLE
Add agent name field in agent table

### DIFF
--- a/maestroqa.helpdesk_id_email.view.lkml
+++ b/maestroqa.helpdesk_id_email.view.lkml
@@ -7,6 +7,12 @@ view: helpdesk_id_email {
     sql: ${TABLE}.email ;;
   }
 
+  dimension: agent_primary_name {
+    description: "Agent primary name of this helpdesk agent"
+    type: string
+    sql: ${TABLE}.agent_primary_name ;;
+  }
+
   dimension: helpdesk_id {
     description: "String cast Salesforce/Zendesk/Desk/Freshdesk  agent ID "
     type: string

--- a/maestroqa.helpdesk_id_email.view.lkml
+++ b/maestroqa.helpdesk_id_email.view.lkml
@@ -7,10 +7,10 @@ view: helpdesk_id_email {
     sql: ${TABLE}.email ;;
   }
 
-  dimension: agent_primary_name {
-    description: "Agent primary name of this helpdesk agent"
+  dimension: agent_name {
+    description: "Name of agent"
     type: string
-    sql: ${TABLE}.agent_primary_name ;;
+    sql: ${TABLE}.agent_name ;;
   }
 
   dimension: helpdesk_id {


### PR DESCRIPTION
## Summary:
In addition to linking the agent id to the agent email in agent table, add linking to the agent name in this table
https://github.com/adtribute/looker-maestroqa/blob/dev-matt-jordan-9wnb/maestroqa.helpdesk_id_email.view.lkml

## Story Link:
https://www.pivotaltracker.com/n/projects/1580581/stories/151110602

## File:
maestroqa.custom_options.view.lkml