### PR TITLE
add reporting date to data warehouse integration

### DIFF
--- a/maestroqa.answers.view.lkml
+++ b/maestroqa.answers.view.lkml
@@ -83,7 +83,7 @@ view: answers {
 
   dimension: reported {
     description: "UTC time this answer was reported"
-    type: date
+    type: time
     sql: ${TABLE}.reported_at ;;
   }
 

--- a/maestroqa.answers.view.lkml
+++ b/maestroqa.answers.view.lkml
@@ -81,6 +81,12 @@ view: answers {
     sql: ${TABLE}.updated_at ;;
   }
 
+  dimension: reported {
+    description: "UTC time this answer was reported"
+    type: date
+    sql: ${TABLE}.reported_at ;;
+  }
+
   dimension: row_updated_at {
     description: "UTC time this row was last updated"
     type: time


### PR DESCRIPTION
## Summary:
Right now we cant get reports based on the manually set reporting date because there is not a column for that field in the data warehouse integrations. Should add reporting date to the grades table in the data warehouse.
## Story Link:
https://www.pivotaltracker.com/n/projects/1580581/stories/152646141
## File Name:
maestroqa.user_groups.view.lkml