### PR TITLE
add agent availability to data warehouse integration

### DIFF
--- a/maestroqa.helpdesk_id_email.view.lkml
+++ b/maestroqa.helpdesk_id_email.view.lkml
@@ -13,6 +13,12 @@ view: helpdesk_id_email {
     sql: ${TABLE}.agent_name ;;
   }
 
+  dimension: agent_availability {
+    type: yesno
+    description: "Availability of this agent"
+    sql: ${TABLE}.agent_availability ;;
+  }
+
   dimension: helpdesk_id {
     description: "String cast Salesforce/Zendesk/Desk/Freshdesk  agent ID "
     type: string

--- a/maestroqa.user_groups.view.lkml
+++ b/maestroqa.user_groups.view.lkml
@@ -7,6 +7,12 @@ view: user_groups {
     sql: ${TABLE}.agent_id ;;
   }
 
+  dimension: agent_availability {
+    type: yesno
+    description: "Availability of this agent"
+    sql: ${TABLE}.agent_availability ;;
+  }
+
   dimension: group_id {
     type: string
     description: "Identifier of this group"

--- a/maestroqa.user_groups.view.lkml
+++ b/maestroqa.user_groups.view.lkml
@@ -7,12 +7,6 @@ view: user_groups {
     sql: ${TABLE}.agent_id ;;
   }
 
-  dimension: agent_availability {
-    type: yesno
-    description: "Availability of this agent"
-    sql: ${TABLE}.agent_availability ;;
-  }
-
   dimension: group_id {
     type: string
     description: "Identifier of this group"


### PR DESCRIPTION
## Summary:
Right now there does not seem to be a way to detect if an agent is or is not available in maestro which would be very helpful to filter on in BI tools. Otherwise need to maintain their own list somehow to ensure they are looking at the right stats. 

Should add agent availability status to the agents table in the data warehouse table so people can make more accurate reports and match up to our dashboard.
## Story Link:
https://www.pivotaltracker.com/n/projects/1580581/stories/147623607
## File Name:
maestroqa.user_groups.view.lkml