### PR TITLE
Format time dimensions consistently as dimension_groups

### DIFF
--- a/maestroqa.answers.view.lkml
+++ b/maestroqa.answers.view.lkml
@@ -17,7 +17,6 @@ view: answers {
 
   dimension_group: created {
     description: "UTC time this answer was created"
-    convert_tz: yes
     type: time
     timeframes: [time, date, week, month]
     sql: ${TABLE}.created_at ;;
@@ -81,15 +80,17 @@ view: answers {
     sql: ${TABLE}.updated_at ;;
   }
 
-  dimension: reported {
+  dimension_group: reported {
     description: "UTC time this answer was reported"
     type: time
+    timeframes: [time, date, week, month]
     sql: ${TABLE}.reported_at ;;
   }
 
-  dimension: row_updated_at {
+  dimension_group: row_updated {
     description: "UTC time this row was last updated"
     type: time
+    timeframes: [time, date, week, month]
     sql: ${TABLE}.row_updated_at ;;
   }
 

--- a/maestroqa.custom_options.view.lkml
+++ b/maestroqa.custom_options.view.lkml
@@ -41,9 +41,10 @@ view: custom_options {
     sql: ${TABLE}.template_id ;;
   }
 
-  dimension: row_updated_at {
+  dimension_group: row_updated {
     description: "UTC time this row was last updated"
     type: time
+    timeframes: [time, date, week, month]
     sql: ${TABLE}.row_updated_at ;;
   }
 

--- a/maestroqa.feedback_options.view.lkml
+++ b/maestroqa.feedback_options.view.lkml
@@ -41,9 +41,10 @@ view: feedback_options {
     sql: ${TABLE}.template_id ;;
   }
 
-  dimension: row_updated_at {
+  dimension_group: row_updated {
     description: "UTC time this row was last updated"
     type: time
+    timeframes: [time, date, week, month]
     sql: ${TABLE}.row_updated_at ;;
   }
 

--- a/maestroqa.feedback_selections.view.lkml
+++ b/maestroqa.feedback_selections.view.lkml
@@ -35,9 +35,10 @@ view: feedback_selections {
     sql: ${TABLE}.option_id ;;
   }
 
-  dimension: row_updated_at {
+  dimension_group: row_updated {
     description: "UTC time this row was last updated"
     type: time
+    timeframes: [time, date, week, month]
     sql: ${TABLE}.row_updated_at ;;
   }
 

--- a/maestroqa.helpdesk_id_email.view.lkml
+++ b/maestroqa.helpdesk_id_email.view.lkml
@@ -31,9 +31,10 @@ view: helpdesk_id_email {
     sql: ${TABLE}.id_type ;;
   }
 
-  dimension: row_updated_at {
+  dimension_group: row_updated {
     description: "UTC time this row was last updated"
     type: time
+    timeframes: [time, date, week, month]
     sql: ${TABLE}.row_updated_at ;;
   }
 

--- a/maestroqa.option_selections.view.lkml
+++ b/maestroqa.option_selections.view.lkml
@@ -35,9 +35,10 @@ view: option_selections {
     sql: ${TABLE}.option_id ;;
   }
 
-  dimension: row_updated_at {
+  dimension_group: row_updated {
     description: "UTC time this row was last updated"
     type: time
+    timeframes: [time, date, week, month]
     sql: ${TABLE}.row_updated_at ;;
   }
 

--- a/maestroqa.question_scores.view.lkml
+++ b/maestroqa.question_scores.view.lkml
@@ -53,9 +53,10 @@ view: question_scores {
     sql: ${TABLE}.template_id ;;
   }
 
-  dimension: row_updated_at {
+  dimension_group: row_updated {
     description: "UTC time this row was last updated"
     type: time
+    timeframes: [time, date, week, month]
     sql: ${TABLE}.row_updated_at ;;
   }
 

--- a/maestroqa.questions.view.lkml
+++ b/maestroqa.questions.view.lkml
@@ -59,9 +59,10 @@ view: questions {
     sql: ${TABLE}.template_id ;;
   }
 
-  dimension: row_updated_at {
+  dimension_group: row_updated {
     description: "UTC time this row was last updated"
     type: time
+    timeframes: [time, date, week, month]
     sql: ${TABLE}.row_updated_at ;;
   }
 

--- a/maestroqa.section_scores.view.lkml
+++ b/maestroqa.section_scores.view.lkml
@@ -40,9 +40,10 @@ view: section_scores {
     sql: ${TABLE}.template_id ;;
   }
 
-  dimension: row_updated_at {
+  dimension_group: row_updated {
     description: "UTC time this row was last updated"
     type: time
+    timeframes: [time, date, week, month]
     sql: ${TABLE}.row_updated_at ;;
   }
 

--- a/maestroqa.sections.view.lkml
+++ b/maestroqa.sections.view.lkml
@@ -47,9 +47,10 @@ view: sections {
     sql: ${TABLE}.template_id ;;
   }
 
-  dimension: row_updated_at {
+  dimension_group: row_updated {
     description: "UTC time this row was last updated"
     type: time
+    timeframes: [time, date, week, month]
     sql: ${TABLE}.row_updated_at ;;
   }
 

--- a/maestroqa.user_groups.view.lkml
+++ b/maestroqa.user_groups.view.lkml
@@ -19,9 +19,10 @@ view: user_groups {
     sql: ${TABLE}.group_name ;;
   }
 
-  dimension: row_updated_at {
+  dimension_group: row_updated {
     description: "UTC time this row was last updated"
     type: time
+    timeframes: [time, date, week, month]
     sql: ${TABLE}.row_updated_at ;;
   }
 


### PR DESCRIPTION
Format time dimensions consistently as dimension_groups
Keep any timezone handling the same between fields
Drop the `_at` suffix consistently