### PR TITLE
Drop support for average_total_score in answers view

### DIFF
--- a/maestroqa.answers.view.lkml
+++ b/maestroqa.answers.view.lkml
@@ -106,10 +106,4 @@ view: answers {
     drill_fields: [answer_id, templates.name, templates.template_id, question_scores.count, section_scores.count]
   }
 
-  measure: average_total_score {
-    type: average
-    sql:  ${total_score} ;;
-    value_format_name: decimal_2
-  }
-
 }


### PR DESCRIPTION
No one knows looker well enough to support things that cause additional customer confusion (e.g. Mailchimp on a few hundreds difference on this column). Let's refocus expectations back to what comes from the data warehouse and let people do their own aggregations.